### PR TITLE
Increase EUnit test stability

### DIFF
--- a/include/couch_db.hrl
+++ b/include/couch_db.hrl
@@ -229,3 +229,10 @@
     atts = []
 }).
 
+
+-type doc() :: #doc{}.
+-type ddoc() :: #doc{}.
+-type user_ctx() :: #user_ctx{}.
+-type sec_props() :: [tuple()].
+-type sec_obj() :: {sec_props()}.
+

--- a/src/couch_doc.erl
+++ b/src/couch_doc.erl
@@ -48,13 +48,20 @@ to_json_body(true, {Body}) ->
 to_json_body(false, {Body}) ->
     Body.
 
-to_json_revisions(Options, Start, RevIds) ->
-    case lists:member(revs, Options) of
-    false -> [];
-    true ->
+to_json_revisions(Options, Start, RevIds0) ->
+    RevIds = case proplists:get_value(revs, Options) of
+        true ->
+            RevIds0;
+        Num when is_integer(Num), Num > 0 ->
+            lists:sublist(RevIds0, Num);
+        _ ->
+           []
+    end,
+    if RevIds == [] -> []; true ->
         [{<<"_revisions">>, {[{<<"start">>, Start},
-                {<<"ids">>, [revid_to_str(R) ||R <- RevIds]}]}}]
+            {<<"ids">>, [revid_to_str(R) ||R <- RevIds]}]}}]
     end.
+
 
 revid_to_str(RevId) when size(RevId) =:= 16 ->
     ?l2b(couch_util:to_hex(RevId));


### PR DESCRIPTION
 * couchdb_1283 : suspend compaction process to reduce chance of
   race condition between it finishing and Writer3 process opening
   a database handle. Writer3 should fail because compactor should
   be keeping its handle.  (@Kxepal, thanks for the idea!)

 * In couchdb_1309, when waiting for view cleanup, test once,
   if fails due to race condition, wait a second and try again.

 * Increase wait time to wait for compactor to stabilize runs on
 slower machines.

COUCHDB-2848